### PR TITLE
Change dist folder to be relative to source

### DIFF
--- a/release-iccj.bash
+++ b/release-iccj.bash
@@ -25,7 +25,7 @@ user=$2
 group=$3
 dir=/opt
 iccdir=$dir/icc
-dist=~/projects/dist
+dist=$PWD/dist
 
 if [ -d $dir/icc-pre-${version} ]; then
     rm -rf $dir/icc-pre-${version} > /dev/null 2>&1 


### PR DESCRIPTION
The old release script referenced `$HOME/projects/dist`. We have no reason to assume that folder exists, and it's not reasonable to expect someone to create that folder before packaging a release.